### PR TITLE
Feat/#52 change student status hired

### DIFF
--- a/src/student/student.controller.ts
+++ b/src/student/student.controller.ts
@@ -2,6 +2,7 @@ import { Controller,
     Get,
     Inject,
     Param,
+    Patch,
     Post,
     UploadedFile,
     UploadedFiles,
@@ -12,7 +13,7 @@ import { Controller,
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
 import { AuthGuard } from '@nestjs/passport';
 import { destionation } from 'src/multer/multer.storage';
-import { UploadeFileMulter } from 'src/types';
+import {ChangeStudentStatusResponse, UploadeFileMulter } from 'src/types';
 import { FileTypeValidationPipe } from 'src/pipe/file-validation.pipe';
 import { AcceptableExceptionFilter } from 'src/filter/not-acceptable.filter';
 import { StudentService } from './student.service';
@@ -77,11 +78,11 @@ export class StudentController {
         }
     }
 
-    @Post('/:id/:status')
+    @Patch('/:id/:status')
     async changeStatus(
         @Param('id') id: string,
         @Param('status') status: UserStatus,
-    ) {
+    ): Promise<ChangeStudentStatusResponse> {
         try {
             const result = await this.studentService.changeStatus(id, status);
             return {

--- a/src/student/student.controller.ts
+++ b/src/student/student.controller.ts
@@ -1,4 +1,14 @@
-import { Controller, Get, Inject, Post, UploadedFile, UploadedFiles, UseFilters, UseGuards, UseInterceptors } from '@nestjs/common';
+import { Controller,
+    Get,
+    Inject,
+    Param,
+    Post,
+    UploadedFile,
+    UploadedFiles,
+    UseFilters,
+    UseGuards,
+    UseInterceptors
+} from '@nestjs/common';
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
 import { AuthGuard } from '@nestjs/passport';
 import { destionation } from 'src/multer/multer.storage';
@@ -7,6 +17,7 @@ import { FileTypeValidationPipe } from 'src/pipe/file-validation.pipe';
 import { AcceptableExceptionFilter } from 'src/filter/not-acceptable.filter';
 import { StudentService } from './student.service';
 import { StudentEntity } from './student.entity';
+import { UserStatus } from 'src/types';
 
 @Controller('student')
 export class StudentController {
@@ -53,6 +64,26 @@ export class StudentController {
     async getFreeStudents() {
         try {
             const result = await this.studentService.getFreeStudnetList();
+            return {
+                actionStatus: true,
+                data: result
+            }
+        } catch (err) {
+            console.log(err)
+            return {
+                actionStatus: false,
+                data: null
+            }
+        }
+    }
+
+    @Post('/:id/:status')
+    async changeStatus(
+        @Param('id') id: string,
+        @Param('status') status: UserStatus,
+    ) {
+        try {
+            const result = await this.studentService.changeStatus(id, status);
             return {
                 actionStatus: true,
                 data: result

--- a/src/student/student.controller.ts
+++ b/src/student/student.controller.ts
@@ -2,6 +2,7 @@ import { Controller,
     Get,
     Inject,
     Param,
+    Patch,
     Post,
     UploadedFile,
     UploadedFiles,
@@ -12,7 +13,7 @@ import { Controller,
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
 import { AuthGuard } from '@nestjs/passport';
 import { destionation } from 'src/multer/multer.storage';
-import { UploadeFileMulter } from 'src/types';
+import {ChangeStudentStatusResponse, UploadeFileMulter } from 'src/types';
 import { FileTypeValidationPipe } from 'src/pipe/file-validation.pipe';
 import { AcceptableExceptionFilter } from 'src/filter/not-acceptable.filter';
 import { StudentService } from './student.service';
@@ -77,11 +78,12 @@ export class StudentController {
         }
     }
 
-    @Post('/:id/:status')
+    @Patch('/:id/:status')
+    //@UseGuards(AuthGuard('jwt')) // do testów nieaktywne, jeszcze nie przetestowane
     async changeStatus(
         @Param('id') id: string,
         @Param('status') status: UserStatus,
-    ) {
+    ): Promise<ChangeStudentStatusResponse> {
         try {
             const result = await this.studentService.changeStatus(id, status);
             return {

--- a/src/student/student.service.ts
+++ b/src/student/student.service.ts
@@ -69,7 +69,7 @@ export class StudentService {
         return toSend;
     }
 
-    async changeStatus(id: string, status: UserStatus) {
+    async changeStatus(id: string, status: UserStatus): Promise<string> {
         const student = await StudentEntity.findOneOrFail({
             relations: ['user'],
             where: {
@@ -79,8 +79,10 @@ export class StudentService {
 
         switch (status) {
             case UserStatus.AVAILABLE:
+                //recruiter does it
                 break;
             case UserStatus.DURING:
+                //recruiter does it
                 break;
             case UserStatus.HIRED:
                 student.reservationStatus = UserStatus.HIRED;

--- a/src/student/student.service.ts
+++ b/src/student/student.service.ts
@@ -9,7 +9,7 @@ import { UserEntity } from 'src/auth/user.entity';
 import { randomSigns } from 'src/utils/random-signs';
 import { safetyConfiguration } from 'config';
 import { sendActivationLink } from 'src/utils/email-handler';
-import { UserStatus } from 'src/types/user/user.status';
+import { UserStatus } from 'src/types';
 
 
 @Injectable()
@@ -69,4 +69,30 @@ export class StudentService {
         return toSend;
     }
 
+    async changeStatus(id: string, status: UserStatus) {
+        const student = await StudentEntity.findOneOrFail({
+            relations: ['user'],
+            where: {
+                id
+            }
+        });
+
+        switch (status) {
+            case UserStatus.AVAILABLE:
+                break;
+            case UserStatus.DURING:
+                break;
+            case UserStatus.HIRED:
+                student.reservationStatus = UserStatus.HIRED;
+                student.user.isActive = false;
+                student.save();
+                student.user.save();
+                break;
+            default:
+                throw new Error('unknown status');
+        }
+
+        return `student status for student id: ${id} was changed into: ${status}`;
+
+    }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,4 +2,5 @@ export * from './user';
 export * from './hr';
 export * from './admin';
 export * from './file';
+export * from './student';
 

--- a/src/types/student/index.ts
+++ b/src/types/student/index.ts
@@ -1,0 +1,1 @@
+export * from './student.response';

--- a/src/types/student/student.response.ts
+++ b/src/types/student/student.response.ts
@@ -1,0 +1,4 @@
+export interface ChangeStudentStatusResponse {
+    actionStatus: boolean;
+    data: string | null;
+}

--- a/src/types/user/index.ts
+++ b/src/types/user/index.ts
@@ -1,2 +1,3 @@
 export * from './user.type';
+export * from './user.status';
 export * from './user.import.type';


### PR DESCRIPTION
[aktualizacja - dodano commit]
- działa dla NIE zalogowanego użytkownika, nie umiem niestety ustawić autoryzacji, w tym temacie mam jeszcze braki
- endpoint jest zrobiony uniwersalnie tak że będzie można dodać potem zmiane na inne statusy, chyba że tu dopisze dla inncyh zanim zmergujemy (jednak po zastanowieniu pozostałe statusy chyba będą zmieniane przez HR)
- testowanie w przeglądarce w consoli przy otwartej na localhost:3001, id studenta oczywiście trzeba zmienić chyba że korzystacie z pliku z INSERTAMI

[PATCH] /student/:id/:status
--------------------
(async () => {const res = await fetch('/student/18676512-1989-421f-a62e-87ec5bf3e82d/hired',{method: 'PATCH'}); console.log(await res.json())})();